### PR TITLE
Refactor train_safe_agent

### DIFF
--- a/examples/unity-simple-examples/README.md
+++ b/examples/unity-simple-examples/README.md
@@ -1,6 +1,6 @@
-# Interface with Unity3D 
-This folder contains a series of basic examples to connect 
-the [Stable Baselines](https://github.com/hill-a/stable-baselines/tree/v2.10.0) framework for reinforcement learning 
+# Interface with Unity3D
+This folder contains a series of basic examples to connect
+the [Stable Baselines](https://github.com/hill-a/stable-baselines/tree/v2.10.0) framework for reinforcement learning
 with Unity environments via [gym-unity](https://github.com/Unity-Technologies/ml-agents/tree/0.15.1/gym-unity).
 
 The examples will use the environments provided in the [EnvBuild](../EnvBuild/) folder.
@@ -11,7 +11,7 @@ To load a Unity environment as a Gym environment, the basic steps to follow are:
 
 ```python
 ...
-# Loading Unity Environment 
+# Loading Unity Environment
 env = UnityEnv(env_name,...)
 action = env.action_space.sample()
 # Interact with the Unity environment as a `gym` environment
@@ -23,8 +23,8 @@ See more [here](https://github.com/Unity-Technologies/ml-agents/tree/0.15.1/gym-
 ## Train a RL agent in a Unity3D Environment
 `train_agent.py` shows how to train your first RL agent using Stable Baselines.
 
-To train an agent in a safe environment, use the [`../EnvBuild/SafeDroneDelivery`](../EnvBuild/SafeDroneDelivery.md) 
-environment. As certain safety constraints are embedded into the environment, the agent can only perform verified 
+To train an agent in a safe environment, use the [`../EnvBuild/SafeDroneDelivery`](../EnvBuild/SafeDroneDelivery.md)
+environment. As certain safety constraints are embedded into the environment, the agent can only perform verified
 safe actions in SafeDroneDelivery.
 
 An example using this environment is shown below:
@@ -53,9 +53,9 @@ env.close()
 
 
 ## Train a safe agent in a Unity3D Environment
-In `safe_policy` are classes `SafePolicy` and `SafeMonitor`. `SafePolicy` checks if each chosen action is safe. If not, 
-a safe action is found by randomly sampling the space around. With this policy, the agent can train in any environment 
-and ensure safety. `SafeMonitor` is a monitor wrapper that tracks collisions that occur while training.  
+In `safe_policy` are classes `SafePolicy` and `SafeMonitor`. `SafePolicy` checks if each chosen action is safe. If not,
+a safe action is found by randomly sampling the space around. With this policy, the agent can train in any environment
+and ensure safety. `SafeMonitor` is a monitor wrapper that tracks collisions that occur while training.
 
 Below is an example training a safe agent using `PPO2` from Stable Baselines with these classes:
 ```python
@@ -70,7 +70,7 @@ os.makedirs(log_dir, exist_ok=True)
 
 file_name = 'DroneDelivery'
 env_name = "../EnvBuild/" + file_name
-unity_env = UnityEnv(env_name, worker_id=10, use_visual=False)
+unity_env = UnityEnv(env_name, worker_id=10, use_visual=False, no_graphics=False)
 
 # Wrap environment to keep track of collisions
 safe_monitor = SafeMonitor(unity_env, log_dir)

--- a/examples/unity-simple-examples/README.md
+++ b/examples/unity-simple-examples/README.md
@@ -59,9 +59,11 @@ and ensure safety. `SafeMonitor` is a monitor wrapper that tracks collisions tha
 
 Below is an example training a safe agent using `PPO2` from Stable Baselines with these classes:
 ```python
+import os
 from gym_unity.envs import UnityEnv
 from stable_baselines import PPO2
-from safe_policy import SafePolicy 
+from stable_baselines.common.vec_env import DummyVecEnv
+from safe_policy import SafeMonitor, SafePolicy
 
 log_dir = "tmp_log/"
 os.makedirs(log_dir, exist_ok=True)

--- a/examples/unity-simple-examples/safe_policy.py
+++ b/examples/unity-simple-examples/safe_policy.py
@@ -115,7 +115,7 @@ class SafePolicy(ActorCriticPolicy):
         # if the action is safe, use it. otherwise, check another possible action
         if not is_action_safe(drone_info, action[VEL_X])[0]:
             safe_actions = []
-            for i in range(max_tries):
+            for _ in range(max_tries):
                 alternative_action = [10 * (random.random() - 0.5), 10 * (random.random() - 0.5)]
                 if is_action_safe(drone_info, alternative_action)[0]:
                     safe_actions.append(alternative_action)

--- a/examples/unity-simple-examples/safe_policy.py
+++ b/examples/unity-simple-examples/safe_policy.py
@@ -1,3 +1,10 @@
+#
+# Copyright (C) 2020 IBM. All Rights Reserved.
+#
+# See LICENSE.txt file in the root directory
+# of this source tree for licensing information.
+#
+
 import csv
 import random
 import time

--- a/examples/unity-simple-examples/safe_policy.py
+++ b/examples/unity-simple-examples/safe_policy.py
@@ -1,24 +1,14 @@
-#
-# Copyright (C) 2020 IBM. All Rights Reserved.
-#
-# See LICENSE.txt file in the root directory
-# of this source tree for licensing information.
-#
-
 import csv
-import os
 import random
 import time
 import gym
-import matplotlib.pyplot as plt
 import numpy as np
+import matplotlib.pyplot as plt
 import tensorflow as tf
-from gym_unity.envs import UnityEnv
-from stable_baselines import PPO2
-from stable_baselines.bench import Monitor
 from stable_baselines.common.policies import ActorCriticPolicy, mlp_extractor
 from stable_baselines.common.tf_layers import linear
-from stable_baselines.common.vec_env import DummyVecEnv
+from stable_baselines.bench import Monitor
+
 
 delta_time = 0.1
 num_animated = 3
@@ -26,7 +16,6 @@ animated_start_index = 4
 max_tries = 100
 tree_start_index = animated_start_index + num_animated * 3
 num_trees = 3
-learning_rate = 5.0e-4
 SAFE_SEP = 0.3
 SAFE_SEP_DOG = 0.4
 INDEX_DRONE_DISTANCE_TARGET = 0
@@ -34,10 +23,8 @@ INDEX_DRONE_POS_X = 1
 INDEX_DRONE_POS_Y = 2
 VEL_X = 0
 VEL_Y = 0
-PlotInfoYN = False
 
 
-# Safe policy of three layers of size 256 each
 class SafePolicy(ActorCriticPolicy):
     """
     Safe Policy object that implements actor critic with a choice of Safe Actions, using a feed forward neural network.
@@ -83,9 +70,6 @@ class SafePolicy(ActorCriticPolicy):
         Parameters:
             obs ([float]): Observation vector
         """
-        if PlotInfoYN:
-            return
-
         drone_info = obs[0]
 
         plt.clf()
@@ -98,36 +82,6 @@ class SafePolicy(ActorCriticPolicy):
             ox = drone_info[i + 1]
             oy = drone_info[i + 2]
             plt.plot(ox, oy, 'o', color='r')
-
-    @staticmethod
-    def __plot_new_safe_position(drone_info, new_velocity):
-        if PlotInfoYN:
-            plt.plot(drone_info[INDEX_DRONE_POS_X] + new_velocity[VEL_X] * delta_time,
-                     drone_info[INDEX_DRONE_POS_Y] + new_velocity[VEL_Y] * delta_time, 'sy')
-
-    @staticmethod
-    def __plot_position_valid_after_colision(drone_info, new_velocity):
-        if PlotInfoYN:
-            plt.plot(drone_info[INDEX_DRONE_POS_X] + new_velocity[VEL_X] * delta_time,
-                     drone_info[INDEX_DRONE_POS_Y] + new_velocity[VEL_Y] * delta_time, '.g')
-
-    @staticmethod
-    def __plot_not_new_valid_position(drone_info, new_velocity):
-        if PlotInfoYN:
-            plt.plot(drone_info[INDEX_DRONE_POS_X] + new_velocity[VEL_X] * delta_time,
-                     drone_info[INDEX_DRONE_POS_Y] + new_velocity[VEL_Y] * delta_time, '.r')
-
-    @staticmethod
-    def __plot_end_step(drone_info, new_velocity):
-        if PlotInfoYN:
-            plt.plot(
-                [drone_info[INDEX_DRONE_POS_X], drone_info[INDEX_DRONE_POS_X] + new_velocity[VEL_X] * delta_time],
-                [drone_info[INDEX_DRONE_POS_Y], drone_info[INDEX_DRONE_POS_Y] + new_velocity[VEL_Y] * delta_time], 'g')
-            plt.xlim([-2, 2])
-            plt.ylim([-2, 0])
-            plt.title(is_action_safe(drone_info, new_velocity))
-            plt.draw()
-            plt.pause(0.0001)
 
     def step(self, obs, state=None, mask=None, deterministic=False):
         """
@@ -152,26 +106,19 @@ class SafePolicy(ActorCriticPolicy):
         drone_info = obs[0]
 
         # if the action is safe, use it. otherwise, check another possible action
-        if is_action_safe(drone_info, action[VEL_X])[0]:
-            self.__plot_new_safe_position(drone_info, action[VEL_X])
-        else:
+        if not is_action_safe(drone_info, action[VEL_X])[0]:
             safe_actions = []
             for i in range(max_tries):
                 alternative_action = [10 * (random.random() - 0.5), 10 * (random.random() - 0.5)]
                 if is_action_safe(drone_info, alternative_action)[0]:
-                    self.__plot_position_valid_after_colision(drone_info, alternative_action[0])
                     safe_actions.append(alternative_action)
                     break
-                else:
-                    self.__plot_not_new_valid_position(drone_info, action[0])
 
             if safe_actions:
                 action = random.choices(safe_actions)
             else:
                 print("No Safe Action found")
                 action = np.array([[0, 0]])
-
-        self.__plot_end_step(drone_info, action[0])
 
         return action, value, self.initial_state, neglogp
 
@@ -315,27 +262,3 @@ class SafeMonitor(Monitor):
 
         self.total_steps += 1
         return observation, reward, done, info
-
-
-if __name__ == '__main__':
-
-    log_dir = "tmp_log/"
-    os.makedirs(log_dir, exist_ok=True)
-
-    file_name = 'DroneDelivery'
-    env_name = "../EnvBuild/" + file_name
-
-    unity_env = UnityEnv(env_name, worker_id=10, use_visual=False)
-    safe_monitor = SafeMonitor(unity_env, log_dir)
-    environment = DummyVecEnv([lambda: safe_monitor])
-
-    if PlotInfoYN:
-        model = PPO2(SafePolicy, environment, verbose=1, learning_rate=learning_rate)
-    else:
-        model = PPO2(SafePolicy, environment, verbose=0, tensorboard_log="./ppo_sb_tensorboard/",
-                     learning_rate=learning_rate)
-
-    model.learn(total_timesteps=1000000, tb_log_name='SafeRL')
-    model.save("unity_SafeRL_model.pkl")
-
-    environment.close()

--- a/examples/unity-simple-examples/train_agent_safe.py
+++ b/examples/unity-simple-examples/train_agent_safe.py
@@ -1,0 +1,22 @@
+import os
+from gym_unity.envs import UnityEnv
+from stable_baselines import PPO2
+from stable_baselines.common.vec_env import DummyVecEnv
+from safe_policy import SafeMonitor, SafePolicy
+
+log_dir = "tmp_log/"
+os.makedirs(log_dir, exist_ok=True)
+
+file_name = 'DroneDelivery'
+env_name = "../EnvBuild/" + file_name
+unity_env = UnityEnv(env_name, worker_id=10, use_visual=False, no_graphics=False)
+
+# Wrap environment to keep track of collisions
+safe_monitor = SafeMonitor(unity_env, log_dir)
+environment = DummyVecEnv([lambda: safe_monitor])
+
+model = PPO2(SafePolicy, environment, verbose=0, tensorboard_log="./ppo_sb_tensorboard/",
+             learning_rate=5.0e-4)
+model.learn(total_timesteps=1000000, tb_log_name='SafeRL')
+model.save("unity_SafeRL_model.pkl")
+environment.close()


### PR DESCRIPTION
Refactor example for training a safe agent
- Rename `train_safe_agent.py` --> `safe_policy.py` and remove plotting related to PlotInfoYN from train_safe_agent
- Update README example